### PR TITLE
[FIX][iot_input] Allow passing number as address

### DIFF
--- a/iot_input/examples/multi_input_values.json
+++ b/iot_input/examples/multi_input_values.json
@@ -1,0 +1,19 @@
+[
+    {
+        "address": "ZMPT101B_1",
+        "value": 230
+    },
+    {
+        "address": 1,
+        "value": true
+    },
+    {
+        "address": 2,
+        "value": "Door opened",
+        "uuid": "abcde"
+    },
+    {
+        "address": 10,
+        "value": -18.5
+    }
+]

--- a/iot_input/models/iot_device.py
+++ b/iot_input/models/iot_device.py
@@ -63,7 +63,8 @@ class IotDevice(models.Model):
                 msg['uuid'] = value['uuid']
             return msg
 
-        device_input = self.input_ids.filtered(lambda i: i.address == value['address'])
+        device_input = self.input_ids.filtered(
+            lambda i: i.address == str(value['address']))
         if len(device_input) == 1:
             res = device_input._call_device(value)
             self.env['iot.device.input.action'].create(

--- a/iot_input/readme/USAGE.rst
+++ b/iot_input/readme/USAGE.rst
@@ -27,7 +27,13 @@ Takes `application/x-www-form-urlencoded` parameters:
 passphase, values (a JSON array of JSON objects)
 
 It is called using device_identification and passing two POST parameters: device passphrase and
-a JSON string containing and array of values for input
+a JSON string containing an array of values for input
+- The value for the `address` key can be a string or a numeric (to conserve bytes in memory
+restricted devices when creating the JSON object) and is converted to string when parsing.
+- The value for the `value` key can either be string, number or boolean according to
+JSON specs.
+You can see an example of a valid JSON input object in the examples folder, using a few
+combinations.
 
 It requires the function that the system will call must be of the following kind::
 
@@ -41,7 +47,7 @@ It requires the function that the system will call must be of the following kind
 Where `key` is a dict send by the device having at least value for keys: 'address', 'value'
 
 The function must always return a JSON with status and message. If value contains a value
-with 'uuid' as key, it is return along with the object for the IoT device to identify
+with 'uuid' as key, it is returned along with the object for the IoT device to identify
 success/failure per record.
 
 It has full error reporting and the return value is a JSON array of dicts containing at

--- a/iot_input/tests/test_iot_in.py
+++ b/iot_input/tests/test_iot_in.py
@@ -134,6 +134,20 @@ class TestIotIn(TransactionCase):
                 [x for x in response_with_uuid if x['uuid'] == response['uuid']][0]
             )
 
+        # Test for address passed as number
+        address_3 = 3
+        self.env['iot.device.input'].create({
+            'name': 'Input 1',
+            'device_id': device.id,
+            'address': address_3,
+            'call_model_id': self.ref('iot_input.model_iot_device_input'),
+            'call_function': 'test_model_function'
+        })
+        for response in device.parse_multi_input(
+            device_identification, passphrase,
+                [{'address': address_3, 'value': 12.3}]):
+            self.assertEqual(response['status'], 'ok')
+
         device.active = False
         self.assertEqual(device.parse_multi_input(
             device_identification, passphrase,


### PR DESCRIPTION
In memory restricted devices (e.g. arduinos et all) sending the input
address as number instead of string in the JSON object can save precious
memory bytes.
This patch allows passing address as number in the JSON object and
converting it to string when parsing.
It also updates USAGE.rst and adds an example JSON.