### PR TITLE
[12.0][UPD]iot,iot_input: set order,skip inactive inputs

### DIFF
--- a/iot/models/iot_device.py
+++ b/iot/models/iot_device.py
@@ -6,6 +6,7 @@ from odoo import api, fields, models
 class IoTDevice(models.Model):
     _name = 'iot.device'
     _description = 'IoT Device'
+    _order = 'name'
 
     name = fields.Char(required=True)
     system_id = fields.Many2one('iot.system', required=True)

--- a/iot_input/models/iot_device.py
+++ b/iot_input/models/iot_device.py
@@ -66,6 +66,15 @@ class IotDevice(models.Model):
         device_input = self.input_ids.filtered(
             lambda i: i.address == str(value['address']))
         if len(device_input) == 1:
+            if not device_input.active:
+                _logger.warning(
+                    'Input with address %s is inactive, no data will be logged',
+                    device_input.address)
+                msg = {'status': 'error',
+                       'message': _('Server Error. Check server logs')}
+                if 'uuid' in value:
+                    msg['uuid'] = value['uuid']
+                return msg
             res = device_input._call_device(value)
             self.env['iot.device.input.action'].create(
                 device_input._add_action_vals(value, res))

--- a/iot_input/models/iot_device_input.py
+++ b/iot_input/models/iot_device_input.py
@@ -5,6 +5,7 @@ from odoo.exceptions import ValidationError
 class IotDeviceInput(models.Model):
     _name = 'iot.device.input'
     _description = "Device input"
+    _order = 'name'
 
     name = fields.Char(required=True)
     device_id = fields.Many2one('iot.device', required=True, readonly=True)


### PR DESCRIPTION
-Sets default order to name for iot_device and iot_input
-Skips parsing data for inactive inputs