### PR TITLE
[FIX] iot_oca,iot_output_oca: Remove unnecessary library

### DIFF
--- a/iot_oca/__manifest__.py
+++ b/iot_oca/__manifest__.py
@@ -18,5 +18,4 @@
         "views/iot_system_views.xml",
         "views/iot_device_views.xml",
     ],
-    "external_dependencies": {"python": ["pyserial>=3"]},
 }

--- a/iot_output_oca/__manifest__.py
+++ b/iot_output_oca/__manifest__.py
@@ -16,5 +16,4 @@
         "views/iot_device_output_views.xml",
         "views/iot_device_views.xml",
     ],
-    "external_dependencies": {"python": ["pyserial>=3"]},
 }


### PR DESCRIPTION
Unnecessary library removed

I was following all the tasks to do the migration but I did not notice that this step was not necessary

Sorry :disappointed: 

@etobella 