### PR TITLE
[12.0][IMP]Add cron to purge iot.device.input.action

### DIFF
--- a/iot_input/__manifest__.py
+++ b/iot_input/__manifest__.py
@@ -15,6 +15,7 @@
     ],
     'maintainers': ['etobella'],
     'data': [
+        'data/ir_cron_data.xml',
         'security/ir.model.access.csv',
         'views/iot_device_views.xml',
         'views/iot_device_input_views.xml',

--- a/iot_input/data/ir_cron_data.xml
+++ b/iot_input/data/ir_cron_data.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+        <record id="ir_cron_mail_notify_channel_moderators" model="ir.cron">
+            <field name="name">IOT: Clear iot.device.input.action table</field>
+            <field name="model_id" ref="model_iot_device_input_action"/>
+            <field name="state">code</field>
+            <field name="code">model.search([]).unlink()</field>
+            <field name="user_id" ref="base.user_root" />
+            <field name="interval_number">7</field>
+            <field name="interval_type">days</field>
+            <field name="numbercall">-1</field>
+            <field name="doall" eval="False"/>
+            <field name="priority">1000</field>
+            <field name="active" eval="False"/>
+        </record>
+    </data>
+</odoo>

--- a/iot_input/readme/USAGE.rst
+++ b/iot_input/readme/USAGE.rst
@@ -53,3 +53,6 @@ success/failure per record.
 It has full error reporting and the return value is a JSON array of dicts containing at
 least status and message. Error message respose is at some points generic, though
 extended logging is done in Odoo server logs.
+
+There is a cron action (that is disabled by default) to clean up the iot.device.input.action
+table every 7 days. That table holds all data sent-received and can usually be purged.


### PR DESCRIPTION
iot.device.input.action holds all data that is sent-received from IOT input
This data is usually not needed after parsing and can be cleaned up to keep
the database size low.
The cron action is disabled by default.