### PR TITLE
[IMP] iot_template_oca: add iot.device.configure access rules

### DIFF
--- a/iot_template_oca/security/ir.model.access.csv
+++ b/iot_template_oca/security/ir.model.access.csv
@@ -7,3 +7,4 @@ access_iot_template_output,access_iot_template_output,model_iot_template_output,
 manage_iot_template_output,access_iot_template_output,model_iot_template_output,iot_oca.group_iot_manager,1,1,1,1
 access_iot_template_key,access_iot_template_key,model_iot_template_key,iot_oca.group_iot_user,1,0,0,0
 manage_iot_template_key,access_iot_template_key,model_iot_template_key,iot_oca.group_iot_manager,1,1,1,1
+access_iot_device_configure,access_iot_device_configure,model_iot_device_configure,iot_oca.group_iot_manager,1,1,1,1


### PR DESCRIPTION
On the migration, I forgot to add the security of the wizard.

Fixing it here. Sorry for the trouble.