### PR TITLE
[IMP] iot: add autovacuum function

### DIFF
--- a/iot_input_oca/__manifest__.py
+++ b/iot_input_oca/__manifest__.py
@@ -15,5 +15,6 @@
         "security/ir.model.access.csv",
         "views/iot_device_views.xml",
         "views/iot_device_input_views.xml",
+        "data/ir_cron.xml",
     ],
 }

--- a/iot_input_oca/data/ir_cron.xml
+++ b/iot_input_oca/data/ir_cron.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="ir_cron_iot_device_input_action" model="ir.cron">
+        <field name='name'>Iot device input actions</field>
+        <field name='interval_number'>1</field>
+        <field name='interval_type'>days</field>
+        <field name="numbercall">-1</field>
+        <field name="active" eval="False" />
+        <field name="doall" eval="False" />
+        <field name="code">model.autovacuum(days=15)</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="model_iot_device_input_action" />
+    </record>
+</odoo>

--- a/iot_input_oca/models/iot_device_input.py
+++ b/iot_input_oca/models/iot_device_input.py
@@ -1,5 +1,6 @@
 import logging
 import traceback
+from datetime import datetime, timedelta
 from io import StringIO
 
 from odoo import _, api, fields, models
@@ -144,3 +145,14 @@ class IoTDeviceAction(models.Model):
     args = fields.Char()
     kwargs = fields.Char()
     res = fields.Char()
+
+    def autovacuum(self, **kwargs):
+        """Delete data older than ``days``.
+        Called from a cron.
+        """
+        deadline = datetime.now() - timedelta(**kwargs)
+        records = self.search([("create_date", "<=", deadline)])
+        nb_records = len(records)
+        records.unlink()
+        _logger.info("AUTOVACUUM - %s '%s' records deleted", nb_records, self._name)
+        return True

--- a/iot_input_oca/tests/test_iot_in.py
+++ b/iot_input_oca/tests/test_iot_in.py
@@ -96,3 +96,17 @@ class TestIotIn(SavepointCase):
         self.assertEqual(self.device_input.action_ids.args, str([args]))
         self.assertEqual(self.device_input.action_ids.res, str(res))
         self.assertEqual(1, self.device_input.action_count)
+
+    def test_cron(self):
+        iot = self.iot.get_device(serial=self.serial, passphrase=self.passphrase)
+        self.assertEqual(self.device_input.action_count, 0)
+        args = "hello"
+        res = iot.call_device(value=args)
+        self.assertEqual(res, {"status": "ok", "value": args})
+        self.assertEqual(self.device_input.action_count, 1)
+        self.env["iot.device.input.action"].autovacuum(days=1)
+        self.device_input.refresh()
+        self.assertEqual(self.device_input.action_count, 1)
+        self.env["iot.device.input.action"].autovacuum(days=0)
+        self.device_input.refresh()
+        self.assertEqual(self.device_input.action_count, 0)

--- a/iot_oca/__manifest__.py
+++ b/iot_oca/__manifest__.py
@@ -20,5 +20,6 @@
         "views/iot_device_group.xml",
         "views/iot_system_views.xml",
         "views/iot_device_views.xml",
+        "data/ir_cron.xml",
     ],
 }

--- a/iot_oca/data/ir_cron.xml
+++ b/iot_oca/data/ir_cron.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="ir_cron_iot_device_action" model="ir.cron">
+        <field name='name'>Iot device actions</field>
+        <field name='interval_number'>1</field>
+        <field name='interval_type'>days</field>
+        <field name="numbercall">-1</field>
+        <field name="active" eval="False" />
+        <field name="doall" eval="False" />
+        <field name="code">model.autovacuum(days=15)</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="model_iot_device_action" />
+    </record>
+</odoo>

--- a/iot_oca/models/iot_device_action.py
+++ b/iot_oca/models/iot_device_action.py
@@ -1,7 +1,12 @@
 # Copyright (C) 2018 Creu Blanca
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+from datetime import datetime, timedelta
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
 
 
 class IoTDeviceAction(models.Model):
@@ -44,3 +49,14 @@ class IoTDeviceAction(models.Model):
                 }
             )
             self.run_extra_actions(status, result)
+
+    def autovacuum(self, **kwargs):
+        """Delete data older than ``days``.
+        Called from a cron.
+        """
+        deadline = datetime.now() - timedelta(**kwargs)
+        records = self.search([("create_date", "<=", deadline)])
+        nb_records = len(records)
+        records.unlink()
+        _logger.info("AUTOVACUUM - %s '%s' records deleted", nb_records, self._name)
+        return True

--- a/iot_oca/tests/test_iot.py
+++ b/iot_oca/tests/test_iot.py
@@ -51,3 +51,21 @@ class TestIoT(TransactionCase):
             self.device.with_context(
                 iot_communication_system_action_id=self.action_2.id
             ).device_run_action()
+
+    def test_cron(self):
+        self.assertEqual(self.device.action_count, 0)
+        with patch(
+            "odoo.addons.iot_oca.models.iot_communication_system_action."
+            "IoTSystemAction._run",
+            return_value=("ok", ""),
+        ):
+            self.device.with_context(
+                iot_communication_system_action_id=self.action.id
+            ).device_run_action()
+        self.assertEqual(self.device.action_count, 1)
+        self.env["iot.device.action"].autovacuum(days=1)
+        self.device.refresh()
+        self.assertEqual(self.device.action_count, 1)
+        self.env["iot.device.action"].autovacuum(days=0)
+        self.device.refresh()
+        self.assertEqual(self.device.action_count, 0)

--- a/iot_output_oca/__manifest__.py
+++ b/iot_output_oca/__manifest__.py
@@ -16,5 +16,6 @@
         "security/ir.model.access.csv",
         "views/iot_device_output_views.xml",
         "views/iot_device_views.xml",
+        "data/ir_cron.xml",
     ],
 }

--- a/iot_output_oca/data/ir_cron.xml
+++ b/iot_output_oca/data/ir_cron.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo noupdate="1">
+    <record id="ir_cron_iot_device_output_action" model="ir.cron">
+        <field name='name'>Iot device output actions</field>
+        <field name='interval_number'>1</field>
+        <field name='interval_type'>days</field>
+        <field name="numbercall">-1</field>
+        <field name="active" eval="False" />
+        <field name="doall" eval="False" />
+        <field name="code">model.autovacuum(days=15)</field>
+        <field name="state">code</field>
+        <field name="model_id" ref="model_iot_device_output_action" />
+    </record>
+</odoo>

--- a/iot_output_oca/models/iot_device_output_action.py
+++ b/iot_output_oca/models/iot_device_output_action.py
@@ -1,7 +1,12 @@
 # Copyright (C) 2018 Creu Blanca
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+import logging
+from datetime import datetime, timedelta
+
 from odoo import _, api, fields, models
 from odoo.exceptions import ValidationError
+
+_logger = logging.getLogger(__name__)
 
 
 class IoTDeviceOutputAction(models.Model):
@@ -44,3 +49,14 @@ class IoTDeviceOutputAction(models.Model):
                 }
             )
             self.run_extra_actions(status, result)
+
+    def autovacuum(self, **kwargs):
+        """Delete data older than ``days``.
+        Called from a cron.
+        """
+        deadline = datetime.now() - timedelta(**kwargs)
+        records = self.search([("create_date", "<=", deadline)])
+        nb_records = len(records)
+        records.unlink()
+        _logger.info("AUTOVACUUM - %s '%s' records deleted", nb_records, self._name)
+        return True

--- a/iot_output_oca/tests/test_iot.py
+++ b/iot_output_oca/tests/test_iot.py
@@ -71,3 +71,21 @@ class TestIoT(TransactionCase):
             self.output.with_context(
                 iot_communication_system_action_id=self.action_2.id
             ).device_run_action()
+
+    def test_cron(self):
+        self.assertEqual(self.output.action_count, 0)
+        with patch(
+            "odoo.addons.iot_oca.models.iot_communication_system_action."
+            "IoTSystemAction._run",
+            return_value=("ok", ""),
+        ):
+            self.output.with_context(
+                iot_communication_system_action_id=self.action.id
+            ).device_run_action()
+        self.assertEqual(self.output.action_count, 1)
+        self.env["iot.device.output.action"].autovacuum(days=1)
+        self.output.refresh()
+        self.assertEqual(self.output.action_count, 1)
+        self.env["iot.device.output.action"].autovacuum(days=0)
+        self.output.refresh()
+        self.assertEqual(self.output.action_count, 0)


### PR DESCRIPTION
The cron action is used to clean up iot actions (iot.device.input.action, iot.communication.system.action, iot.device.action, iot.device.output.action) in order to keep the database size low. Cron tests added.